### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "saucy/saucy": "^1.0 || dev-main",
         "spatie/laravel-package-tools": "^1.16"
     },


### PR DESCRIPTION
## Summary
- Widen `illuminate/contracts` version constraint from `^10.0||^11.0||^12.0` to `^10.0||^11.0||^12.0||^13.0`

## Test plan
- [ ] Verify the package installs correctly in a Laravel 13 project
- [ ] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)