### PR TITLE
Fix analytics endpoints returning __PHP_Incomplete_Class on Laravel 13

### DIFF
--- a/src/Http/Controllers/AnalyticsController.php
+++ b/src/Http/Controllers/AnalyticsController.php
@@ -23,7 +23,8 @@ class AnalyticsController
                 ->map(fn (object $row) => [
                     'hour' => $row->hour,
                     'count' => (int) $row->count,
-                ]);
+                ])
+                ->all();
         });
 
         return response()->json(['throughput' => $throughput]);
@@ -44,7 +45,8 @@ class AnalyticsController
                 ->map(fn (object $row) => [
                     'type' => $row->message_type,
                     'count' => (int) $row->count,
-                ]);
+                ])
+                ->all();
         });
 
         return response()->json(['event_types' => $eventTypes]);


### PR DESCRIPTION
## Summary
- `AnalyticsController::eventThroughput` and `eventTypeDistribution` cached `Illuminate\Support\Collection` instances via `Cache::remember`.
- On Laravel 13 the default `config('cache.serializable_classes')` is `false`, so cached values are unserialized with `allowed_classes => false` and any object comes back as `__PHP_Incomplete_Class`.
- Result: subsequent requests responded with `{"throughput":{"__PHP_Incomplete_Class_Name":"Illuminate\\Support\\Collection"}}` (and the same for event types).
- Fix: call `->all()` on the mapped collection before returning it from the cache closure so a plain array is cached. JSON output is identical.

## Test plan
- [ ] Hit `GET /saucy-dashboard/api/analytics/throughput` twice (first miss, second hit) on a Laravel 13 app with `cache.serializable_classes => false` and confirm the response is a normal array on both calls.
- [ ] Same for `GET /saucy-dashboard/api/analytics/event-types`.
- [ ] Existing dashboard charts (throughput, event type distribution) render unchanged.